### PR TITLE
Don't create `~` subfolder on persistent folder

### DIFF
--- a/info.rttr.Return-To-The-Roots.yaml
+++ b/info.rttr.Return-To-The-Roots.yaml
@@ -12,7 +12,7 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
   - --device=dri
-  - --persist=~/.s25rttr
+  - --persist=.s25rttr
 cleanup:
   - '*.a'
   - '*.la'


### PR DESCRIPTION
Currently, the homedir-relevant path is set by the manifest to `~/.s25rttr`, this however translates to `$HOME/~/.s25rttr`, as `~` is taken as an folder name.

This patch changes it to `.s25rttr`, so that the correct folder is set and the game can actually detect the game files.